### PR TITLE
Connexion rapide vers Archivate (SSO)

### DIFF
--- a/app/controllers/api/archivate/sso_controller.rb
+++ b/app/controllers/api/archivate/sso_controller.rb
@@ -1,0 +1,30 @@
+class Api::Archivate::SsoController < ApiController
+  # validate est appelé de serveur à serveur par Archivate, sans token API.
+  skip_before_action :authenticate, only: [:validate]
+
+  def generate
+    sso_token = current_user.sso_tokens.create!
+
+    render json: {
+      token: sso_token.token,
+      expires_at: sso_token.expires_at,
+      redirect_url: "#{archivate_sso_url}?token=#{sso_token.token}"
+    }, status: :created
+  end
+
+  def validate
+    sso_token = SsoToken.usable.find_by(token: params[:token])
+
+    if sso_token && sso_token.consume!
+      render json: { user: { id: sso_token.user_id, email: sso_token.user.email } }, status: :ok
+    else
+      render json: { error: 'Invalid or expired SSO token' }, status: :unauthorized
+    end
+  end
+
+  private
+
+  def archivate_sso_url
+    Rails.application.secrets.archivate_sso_url || 'http://localhost:3400/v1/auth/sso'
+  end
+end

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -136,6 +136,11 @@ class Api::MenusController < ApiController
           icon: "mdi-vote",
           to: me_votes_path,
         },
+        {
+          title: "Archivate",
+          icon: "mdi-cloud-outline",
+          to: "/archivate",
+        },
       ]
     when 'association'
       result = [

--- a/app/controllers/me/archivate_controller.rb
+++ b/app/controllers/me/archivate_controller.rb
@@ -1,0 +1,5 @@
+class Me::ArchivateController < MeController
+  # Sert la SPA sur /archivate (la redirection SSO est gérée côté Vue).
+  def index
+  end
+end

--- a/app/frontend/components/Archivate/Redirect.vue
+++ b/app/frontend/components/Archivate/Redirect.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-container class="d-flex flex-column align-center justify-center" style="min-height: 60vh">
+    <template v-if="error">
+      <v-icon size="48" color="error" class="mb-4">mdi-alert-circle-outline</v-icon>
+      <p class="text-body-1 mb-4">{{ error }}</p>
+      <v-btn color="primary" @click="redirectToArchivate">Réessayer</v-btn>
+    </template>
+    <template v-else>
+      <v-progress-circular color="primary" indeterminate :size="56" :width="6" class="mb-4" />
+      <p class="text-body-1">Connexion à Archivate…</p>
+    </template>
+  </v-container>
+</template>
+
+<script>
+import axios from "axios";
+
+export default {
+  name: "ArchivateRedirect",
+  data: () => ({
+    error: null,
+  }),
+  methods: {
+    // Génère un jeton SSO à usage unique côté funadf puis redirige l'utilisateur
+    // vers Archivate, qui l'échangera et ouvrira automatiquement sa session.
+    redirectToArchivate() {
+      this.error = null;
+      axios
+        .post("/api/archivate/sso/generate")
+        .then((res) => {
+          window.location.href = res.data.redirect_url;
+        })
+        .catch(() => {
+          this.error = "Impossible d'ouvrir Archivate pour le moment.";
+        });
+    },
+  },
+  mounted() {
+    this.redirectToArchivate();
+  },
+};
+</script>

--- a/app/frontend/router/router.js
+++ b/app/frontend/router/router.js
@@ -18,6 +18,7 @@ import PushNotificationsIndex from "../components/PushNotifications/Index.vue";
 import RegionsIndex from "../pages/Regions/Index.vue";
 import MembersIndex from "../pages/Members/Index.vue";
 import PostsShow from "../pages/Posts/Show.vue";
+import ArchivateRedirect from "../components/Archivate/Redirect.vue";
 import EventsShow from "../pages/Events/Show.vue";
 import ChurchShow from "../pages/Churches/Show.vue";
 
@@ -47,6 +48,11 @@ const router = createRouter({
             path: "/documents",
             component: MeDocumentsIndex,
             name: "documents.index",
+        },
+        {
+            path: "/archivate",
+            component: ArchivateRedirect,
+            name: "archivate.redirect",
         },
         {
             path: "/campaigns",

--- a/app/models/sso_token.rb
+++ b/app/models/sso_token.rb
@@ -1,0 +1,43 @@
+class SsoToken < ActiveRecord::Base
+  # Jeton de connexion rapide (SSO) vers une application tierce (Archivate).
+  # À usage unique et à courte durée de vie : généré quand l'utilisateur clique
+  # sur le lien, échangé une seule fois par l'application cible, puis consommé.
+
+  TTL = 2.minutes
+
+  belongs_to :user
+
+  validates :token, presence: true, uniqueness: true
+  validates :expires_at, presence: true
+
+  before_validation :generate_token, on: :create
+
+  scope :usable, -> { where(used_at: nil).where('expires_at > ?', Time.now) }
+
+  def expired?
+    expires_at <= Time.now
+  end
+
+  def used?
+    used_at.present?
+  end
+
+  def usable?
+    !used? && !expired?
+  end
+
+  # Consomme le jeton (usage unique) et renvoie true s'il était valide.
+  def consume!
+    return false unless usable?
+
+    update!(used_at: Time.now)
+    true
+  end
+
+  private
+
+  def generate_token
+    self.token ||= SecureRandom.hex(32)
+    self.expires_at ||= Time.now + TTL
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,7 @@ class User < ActiveRecord::Base
 
   has_many :notifications, as: :recipient, dependent: :destroy
   has_many :api_tokens, dependent: :destroy
+  has_many :sso_tokens, dependent: :destroy
 
   accepts_nested_attributes_for :careers, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :gratitudes, reject_if: :all_blank, allow_destroy: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,11 @@ Rails.application.routes.draw do
     post 'connect_with_google', to: 'sessions#connect_with_google', as: :connect_with_google
     post 'login', to: 'sessions#login', as: :login
 
+    namespace :archivate do
+      post 'sso/generate', to: 'sso#generate', as: :sso_generate
+      post 'sso/validate', to: 'sso#validate', as: :sso_validate
+    end
+
     get '/:model/config', to: 'config#show'
 
     resources :users
@@ -129,6 +134,7 @@ Rails.application.routes.draw do
     get '/annuaire', to: 'annuaire#show', as: :annuaire
     get '/mon-profil', to: 'profile#show', as: :me
     get '/documents', to: 'documents#index', as: :documents
+    get '/archivate', to: 'archivate#index', as: :archivate
     get '/campaigns', to: 'campaigns#index', as: :votes
     get '/actus/:post', to: 'posts#show', as: :post
     get '/evenements/:event', to: 'events#show', as: :event

--- a/db/migrate/20260706000000_create_sso_tokens.rb
+++ b/db/migrate/20260706000000_create_sso_tokens.rb
@@ -1,0 +1,14 @@
+class CreateSsoTokens < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sso_tokens do |t|
+      t.references :user, foreign_key: true, type: :integer
+      t.string :token, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :used_at
+
+      t.timestamps
+    end
+
+    add_index :sso_tokens, :token, unique: true
+  end
+end


### PR DESCRIPTION
# Description of the changes

Ajoute une **connexion rapide (SSO) vers Archivate** : un utilisateur connecté à funadf clique sur « Archivate » dans le menu et arrive sur Archivate déjà authentifié, sans ressaisir ses identifiants.

funadf reste la **source de vérité des comptes** : Archivate n'a aucun mot de passe local, il délègue entièrement l'authentification.

**Fonctionnement**

1. L'utilisateur ouvre `/archivate` → `POST /api/archivate/sso/generate` crée un jeton
2. Redirection vers Archivate avec le jeton en paramètre
3. Archivate rappelle `POST /api/archivate/sso/validate` (serveur à serveur) pour l'échanger contre l'identité de l'utilisateur

**Sécurité du jeton** — `SecureRandom.hex(32)` (64 caractères), **usage unique** (`consume!` marque `used_at`), **TTL 2 minutes**, index unique sur `token`. Un jeton rejoué est refusé.

**Fichiers**

| Fichier | Rôle |
|---|---|
| `app/models/sso_token.rb` | Génération, expiration, consommation unique |
| `app/controllers/api/archivate/sso_controller.rb` | `generate` (authentifié) et `validate` (public, serveur à serveur) |
| `db/migrate/20260706000000_create_sso_tokens.rb` | Table `sso_tokens` |
| `config/routes.rb` | `namespace :archivate` sous `/api` |
| `app/models/user.rb` | `has_many :sso_tokens` |
| `app/controllers/api/menus_controller.rb` | Entrée « Archivate » dans le menu |
| `app/frontend/router/router.js` + `components/Archivate/Redirect.vue` | Page `/archivate` qui redirige |
| `app/controllers/me/archivate_controller.rb` + `views/me/archivate/` | Sert la SPA sur `/archivate` |

**Choix suivant les conventions du projet**

- `validate` utilise `skip_before_action :authenticate`, comme `Api::SessionsController` le fait déjà pour `login` — l'appel vient d'Archivate, pas d'un navigateur authentifié
- Migration en `t.references` (convention majoritaire : 22 occurrences contre 3)
- `Rails.application.secrets` pour la configuration, comme le reste du projet
- Vue `index.html.haml` vide, comme toutes les vues servant la SPA (`me/documents`, `me/campaigns`, `me/annuaire`)

---

## ⚠️ Prérequis de déploiement

**1. Jouer la migration**

```bash
rails db:migrate
```

Crée la table `sso_tokens`. **L'entrypoint (`docker-rails.sh`) ne lance pas les migrations** — il démarre directement Unicorn en production. Cette étape doit donc figurer dans le processus de déploiement.

La migration est **purement additive** : elle crée une table, ne touche à aucune table existante, ne supprime rien.

*Testé sur une copie d'une base contenant 1588 utilisateurs : 30 → 31 tables, aucune donnée modifiée, migration enregistrée dans `schema_migrations`.*

**2. Ajouter le secret**

Dans `config/secrets.yml`, section `production` :

```yaml
production:
  archivate_sso_url: https://api.archivate.fr/v1/auth/sso
```

C'est l'URL vers laquelle l'utilisateur est redirigé avec son jeton. Sans elle, le code retombe sur `http://localhost:3400/v1/auth/sso` (valeur de développement).

**3. `db/schema.rb` n'est volontairement pas inclus**

Le régénérer localement produisait ~50 lignes de bruit sans rapport avec cette PR (`charset: "utf8"` → `"utf8mb3"`), dû à une version de MySQL différente de celle de référence. Le fichier étant **dérivé**, il se régénère automatiquement au premier `rails db:migrate`.

À régénérer depuis un environnement aligné sur la production si vous souhaitez le versionner dans cette PR.

---

# Related issues or tasks (if any)

- [ ] _à compléter_

# Type of change

- [ ] 🪲 Bug fix
- [x] ✨ New feature
- [ ] 💎 Improvement
- [ ] 📄 Configuration file, scripts, dependencies, etc...

# Checklist:

- [x] I have performed a self-review of my code
- [x] There are no debugging code (console.log, etc...)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (In browser console and in frontend / backend console)

> Read our standards for [pull request](https://mabible.atlassian.net/wiki/spaces/MAB/pages/62423042/Perfect+Pull+Request)
